### PR TITLE
Added missing go mod ch02/base

### DIFF
--- a/code/ch02/base/go.mod
+++ b/code/ch02/base/go.mod
@@ -1,0 +1,3 @@
+module co11yia/ch2/base
+
+go 1.16

--- a/code/ch02/base/go.mod
+++ b/code/ch02/base/go.mod
@@ -1,3 +1,3 @@
 module co11yia/ch2/base
 
-go 1.16
+go 1.20

--- a/code/ch02/logs/go.mod
+++ b/code/ch02/logs/go.mod
@@ -1,5 +1,5 @@
 module co11yia/ch2/logs
 
-go 1.16
+go 1.20
 
 require github.com/sirupsen/logrus v1.8.1

--- a/code/ch02/metrics/go.mod
+++ b/code/ch02/metrics/go.mod
@@ -1,6 +1,6 @@
-module co11yia/ch2/logs
+module co11yia/ch2/metrics
 
-go 1.16
+go 1.20
 
 require (
 	github.com/prometheus/client_golang v1.11.0

--- a/code/ch02/traces/go.mod
+++ b/code/ch02/traces/go.mod
@@ -1,6 +1,6 @@
-module co11yia/ch2/logs
+module co11yia/ch2/traces
 
-go 1.16
+go 1.20
 
 require (
 	github.com/prometheus/client_golang v1.11.0


### PR DESCRIPTION
Running base example on `ch02/base` yielded this error, due to a missing `go.mod`:

```bash
$ go build -o echosvc .
go: cannot find main module, but found .git/config in /home/ernesto/utn/manning/o11y-in-action.cloud
        to create a module there, run:
        cd ../../.. && go mod init
```        


Adding this mod, the code in the base example worked fine, as stated on the manuscript