### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/code/ch02/logs/docker-compose.yaml
+++ b/code/ch02/logs/docker-compose.yaml
@@ -3,7 +3,7 @@ networks:
   loki:
 services:
   loki:
-    image: grafana/loki:2.4.0
+    image: grafana/loki:2.9.4
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
@@ -18,7 +18,7 @@ services:
     networks:
       - loki
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:10.4.2
     ports:
       - "3000:3000"
     networks:


### PR DESCRIPTION
version 2.4.0 of loki doesn't work with latest version of grafana (Unable to connect with Loki. Please check the server logs for more details) so I upgraded loki and pinned grafana version.